### PR TITLE
Fix #30 and change content model of cover

### DIFF
--- a/geekodoc/rng/geekodoc5-flat.rnc
+++ b/geekodoc/rng/geekodoc5-flat.rnc
@@ -2772,19 +2772,6 @@ div {
         & db.common.attributes
         & db.common.linking.attributes
     }
-    db.cover.contentmodel =
-      (db.para.blocks
-       | db.extension.blocks
-       | db.list.blocks
-       | db.informal.blocks
-       | db.publishing.blocks
-       | db.graphic.blocks
-       | db.technical.blocks
-       | db.verbatim.blocks
-       | db.bridgehead
-       | db.remark
-       | db.revhistory)
-      | db.synopsis.blocks
     div {
       db.cover.role.attribute = attribute role { text }
       db.cover.attlist =
@@ -10086,6 +10073,7 @@ div {
 
   }
   # ======== General Patterns
+  db.cover.contentmodel = db.mediaobject+
   db.nopara.blocks =
     db.list.blocks
     | db.formal.blocks

--- a/geekodoc/rng/geekodoc5.rnc
+++ b/geekodoc/rng/geekodoc5.rnc
@@ -5,7 +5,7 @@
 #
 # This schema is a customization of DocBook for SUSE documents
 #
-# Author: Thomas Schraitle, 2015-2016
+# Author: Thomas Schraitle, 2015-2017
 #
 default namespace db = "http://docbook.org/ns/docbook"
 datatypes xsd = "http://www.w3.org/2001/XMLSchema-datatypes"
@@ -527,6 +527,8 @@ include "docbookxi.rnc"
 
 
   #======== General Patterns
+  db.cover.contentmodel = db.mediaobject+
+
   db.nopara.blocks =
     db.list.blocks
      | db.formal.blocks

--- a/geekodoc/tests/article-cover.xml
+++ b/geekodoc/tests/article-cover.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../rng/geekodoc5-flat.rnc" type="application/relax-ng-compact-syntax"?>
+<article xmlns="http://docbook.org/ns/docbook" xml:lang="en" xml:id="article-base">
+ <title>Test Article with cover</title>
+ <info>
+  <cover>
+   <mediaobject>
+    <imageobject>
+     <imagedata fileref="foo.png"/>
+    </imageobject>
+   </mediaobject>
+  </cover>
+ </info>
+ <para>The quick brown fox jumps over the lazy dog.</para>
+</article>


### PR DESCRIPTION
`cover` now allows one or more `mediaobjects` as child elements