### PR TITLE
nicer test feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ geekodoc/rng/*.srng
 geekodoc/rng/catalog.dtd
 geekodoc/rng/geekodoc5*.rng
 geekodoc/tests/*/*.err
+geekodoc/tests/last-test-run-errors
 
 build/
 autom4te.cache/

--- a/geekodoc/tests/run-tests.sh
+++ b/geekodoc/tests/run-tests.sh
@@ -100,33 +100,19 @@ function test_check()
         good)
             if [[ ! "$RESULT" == '' ]]; then
                 RESULTSTR="\e[1;31mFAILED\e[0m"
+                ERRORS=$(($ERRORS + 1))
             fi
             ;;
         bad)
             if [[ "$RESULT" == '' ]]; then
                 RESULTSTR="\e[1;31mFAILED\e[0m"
+                ERRORS=$(($ERRORS + 1))
             fi
             ;;
         *)
             ;;
     esac
     echo -e $RESULTSTR
-}
-
-function count_errors()
-{
-    case "$1" in
-        good)
-            if [[ ! "$2" == '' ]]; then
-                ERRORS=$(($ERRORS + 1))
-            fi
-            ;;
-        bad)
-            if [[ "$2" == '' ]]; then
-                ERRORS=$(($ERRORS + 1))
-            fi
-            ;;
-    esac
 }
 
 function test_files() {
@@ -149,7 +135,6 @@ function test_files() {
        fi
        result=$(validator $SCHEMA $xmlfile)
        test_check $GOOD_OR_BAD "$result"
-       count_errors $GOOD_OR_BAD "$result"
        if [[ ! "$result" == '' ]]; then
            [[ $GOOD_OR_BAD == 'good' ]] && echo -e "$result"
            echo "###### Errors in '$xmlfile' ######" >> $ERRORFILE

--- a/geekodoc/tests/run-tests.sh
+++ b/geekodoc/tests/run-tests.sh
@@ -17,6 +17,7 @@ PROGDIR=${0%/*}
 SCHEMA=${PROGDIR}/../rng/geekodoc5-flat.rng
 SCHEMA=$(readlink -f ${SCHEMA})
 ERRORS=0
+ERRORFILE=${PROGDIR}/last-test-run-errors
 
 SUCCESS=0
 FAILURE=1
@@ -142,8 +143,10 @@ function test_files() {
        resultstr=$(test_check $GOOD_OR_BAD "$result")
        count_errors $GOOD_OR_BAD "$result"
        echo -e " $resultstr"
-       if [[ $GOOD_OR_BAD == 'good' ]] && [[ ! "$result" == '' ]]; then
-         echo -e "$result"
+       if [[ ! "$result" == '' ]]; then
+           [[ $GOOD_OR_BAD == 'good' ]] && echo -e "$result"
+           echo "###### Errors in '$xmlfile' ######" >> $ERRORFILE
+           echo -e "\n$result\n\n" >> $ERRORFILE
        fi
     done
 }
@@ -213,6 +216,7 @@ fi
 loginfo "Using validator '$VALIDATOR'"
 loginfo "Selected category: '$TEST_CATEGORY'"
 
+rm -r "$ERRORFILE" 2> /dev/null
 
 case "$TEST_CATEGORY" in
   all)
@@ -230,6 +234,7 @@ esac
 
 
 echo
+loginfo "Find all validation errors in $ERRORFILE"
 if [ 0 -eq "$ERRORS" ]; then
     loginfo "Found\e[1;32m $ERRORS errors\e[0m. Congratulations! :-)"
     exit 0

--- a/geekodoc/tests/run-tests.sh
+++ b/geekodoc/tests/run-tests.sh
@@ -110,7 +110,7 @@ function test_check()
         *)
             ;;
     esac
-    echo $RESULTSTR
+    echo -e $RESULTSTR
 }
 
 function count_errors()
@@ -138,11 +138,18 @@ function test_files() {
     local re='^[0-9]+$'
 
     for xmlfile in $DIR/*.xml; do
-       loginfo -n "Validating '$xmlfile'..."
+       loginfo -n "Validating '$xmlfile'... "
+       wellformedness=$(xmllint --noout --noent $xmlfile 2>&1)
+       if [[ ! $wellformedness == '' ]]; then
+           # In this case, we always want to say "FAILED", so this usage is correct.
+           # (But we are abusing the existing test_check() function somewhat.)
+           test_check good 'not good'
+           echo -e "$wellformedness"
+           logerror --fatal "Test case is not well-formed: '$xmlfile'. Quitting."
+       fi
        result=$(validator $SCHEMA $xmlfile)
-       resultstr=$(test_check $GOOD_OR_BAD "$result")
+       test_check $GOOD_OR_BAD "$result"
        count_errors $GOOD_OR_BAD "$result"
-       echo -e " $resultstr"
        if [[ ! "$result" == '' ]]; then
            [[ $GOOD_OR_BAD == 'good' ]] && echo -e "$result"
            echo "###### Errors in '$xmlfile' ######" >> $ERRORFILE


### PR DESCRIPTION
@tomschr, I tried to improve the test runner a bit. Main new features:

* If there is a validation issue in good/, the error message will be written directly to the command line
* All validation errors (both for good/ and bad/) are written to a single file ("last-test-run-errors") which should make it easier to look at them
* All test cases are checked for well-formedness before being run against the RNG

The one main ugly tradeoff I made is that the test runner relies on xmllint/jing command line output now instead of on return codes. I don't think that is a practical issue though.

I didn't do anything about the NovDoc test runner. I suspect it would be easiest to symlink that to the GeekoDoc test runner.

(The commits are not super-clean topic-wise, sorry.)