### PR TITLE
Integrate its:translate into GeekoDoc

### DIFF
--- a/geekodoc/rng/geekodoc5-flat.rnc
+++ b/geekodoc/rng/geekodoc5-flat.rnc
@@ -18,6 +18,7 @@ namespace xlink = "http://www.w3.org/1999/xlink"
 
 s:ns [ uri = "http://docbook.org/ns/docbook" prefix = "db" ]
 s:ns [ uri = "http://www.w3.org/1999/xlink" prefix = "xlink" ]
+s:ns [ uri = "http://www.w3.org/2005/11/its" prefix = "its" ]
 # Constants
 suse.schema.version = "5.1-subset GeekoDoc-1.0.2.1"
 #
@@ -10461,9 +10462,18 @@ div {
     & db.variablelist.termlength.attribute?
   db.warning.attlist = db.warning.role.attribute? & db.common.attributes
   # ========= Changed attributes
-  #
   # Introduce optional its:translate attribute:
-  db.common.base.attributes &= its-attribute.translate?
+  db.common.base.attributes =
+    db.version.attribute?
+    & db.xml.lang.attribute?
+    & db.xml.base.attribute?
+    & db.remap.attribute?
+    & db.xreflabel.attribute?
+    & db.revisionflag.attribute?
+    & db.dir.attribute?
+    & db.effectivity.attributes
+    & db.rdfalite.attributes
+    & its-attribute.translate?
   db.common.data.attributes =
 
     ## Specifies the format of the data
@@ -10936,7 +10946,12 @@ div {
   # see https://www.w3.org/TR/xinclude-11/
   #
   db.any.other.attribute =
-    attribute * - (local:* | trans:* | ns1:* | xlink:* | xml:*) { text }
+    attribute * - (local:*
+                   | trans:*
+                   | ns1:*
+                   | xlink:*
+                   | xml:*
+                   | its:*) { text }
   db.xi.include.attlist =
     db.xi.href.attribute?
     & # (db.xi.href-empty.attribute | db.xi.href-uri.attribute)? &

--- a/geekodoc/rng/geekodoc5-flat.rnc
+++ b/geekodoc/rng/geekodoc5-flat.rnc
@@ -2,6 +2,7 @@ namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 namespace ctrl = "http://nwalsh.com/xmlns/schema-control/"
 default namespace db = "http://docbook.org/ns/docbook"
 namespace html = "http://www.w3.org/1999/xhtml"
+namespace its = "http://www.w3.org/2005/11/its"
 namespace local = "http://www.w3.org/2001/XInclude/local-attributes"
 namespace locattr = "http://www.w3.org/2001/XInclude/local-attributes"
 namespace mml = "http://www.w3.org/1998/Math/MathML"
@@ -65,6 +66,22 @@ div {
         & db.trans.suffix.attribute?
         & db.trans.linkscope.attribute?
     }
+  }
+}
+#
+div {
+  div {
+    its-translate.type =
+
+      ## The nodes need to be translated
+      "yes"
+      |
+        ## The nodes must not be translated
+        "no"
+    its-attribute.translate =
+
+      ## The Translate data category information to be attached to the current node
+      attribute its:translate { its-translate.type }
   }
 }
 # XInclude 1.1
@@ -552,16 +569,6 @@ div {
 
       ## The RDFa Lite prefix
       attribute prefix { text }
-    db.common.base.attributes =
-      db.version.attribute?
-      & db.xml.lang.attribute?
-      & db.xml.base.attribute?
-      & db.remap.attribute?
-      & db.xreflabel.attribute?
-      & db.revisionflag.attribute?
-      & db.dir.attribute?
-      & db.effectivity.attributes
-      & db.rdfalite.attributes
     db.common.attributes =
       db.xml.id.attribute?
       & db.common.base.attributes
@@ -10455,6 +10462,8 @@ div {
   db.warning.attlist = db.warning.role.attribute? & db.common.attributes
   # ========= Changed attributes
   #
+  # Introduce optional its:translate attribute:
+  db.common.base.attributes &= its-attribute.translate?
   db.common.data.attributes =
 
     ## Specifies the format of the data

--- a/geekodoc/rng/geekodoc5.rnc
+++ b/geekodoc/rng/geekodoc5.rnc
@@ -36,6 +36,8 @@ suse.schema.version = "5.1-subset GeekoDoc-1.0.2.1"
 
 #
 include "transclusion.rnc"
+#
+include "its.rnc"
 
 # XInclude 1.1
 div
@@ -1017,6 +1019,9 @@ include "docbookxi.rnc"
 
   #========= Changed attributes
   #
+  # Introduce optional its:translate attribute:
+  db.common.base.attributes &= its-attribute.translate?
+
   db.common.data.attributes =
    ## Specifies the format of the data
    attribute format { db.format.enumeration }?,

--- a/geekodoc/rng/geekodoc5.rnc
+++ b/geekodoc/rng/geekodoc5.rnc
@@ -14,6 +14,7 @@ datatypes xsd = "http://www.w3.org/2001/XMLSchema-datatypes"
 namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 namespace ctrl = "http://nwalsh.com/xmlns/schema-control/"
 namespace html = "http://www.w3.org/1999/xhtml"
+namespace its = "http://www.w3.org/2005/11/its"
 namespace mml = "http://www.w3.org/1998/Math/MathML"
 namespace svg = "http://www.w3.org/2000/svg"
 namespace s = "http://purl.oclc.org/dsdl/schematron"
@@ -29,6 +30,7 @@ namespace trans="http://docbook.org/ns/transclusion"
 # Define some namespaces for Schematron
 s:ns [ uri = "http://docbook.org/ns/docbook" prefix = "db" ]
 s:ns [ uri = "http://www.w3.org/1999/xlink"  prefix = "xlink" ]
+s:ns [ uri = "http://www.w3.org/2005/11/its"  prefix = "its" ]
 
 # Constants
 suse.schema.version = "5.1-subset GeekoDoc-1.0.2.1"
@@ -529,7 +531,6 @@ include "docbookxi.rnc"
   # db.year = notAllowed
   }
 
-
   #======== General Patterns
   db.cover.contentmodel = db.mediaobject+
 
@@ -1018,9 +1019,18 @@ include "docbookxi.rnc"
     & db.common.attributes
 
   #========= Changed attributes
-  #
   # Introduce optional its:translate attribute:
-  db.common.base.attributes &= its-attribute.translate?
+  db.common.base.attributes =
+      db.version.attribute?
+      & db.xml.lang.attribute?
+      & db.xml.base.attribute?
+      & db.remap.attribute?
+      & db.xreflabel.attribute?
+      & db.revisionflag.attribute?
+      & db.dir.attribute?
+      & db.effectivity.attributes
+      & db.rdfalite.attributes
+      & its-attribute.translate?
 
   db.common.data.attributes =
    ## Specifies the format of the data
@@ -1480,7 +1490,7 @@ include "docbookxi.rnc"
   # see https://www.w3.org/TR/xinclude-11/
   #
   db.any.other.attribute = attribute *
-                           - (locattr:* | trans:* | local:* | xlink:* | xml:* )
+                           - (locattr:* | trans:* | local:* | xlink:* | xml:* | its:*)
                            { text }
   db.xi.include.attlist =
     db.xi.href.attribute? &

--- a/geekodoc/rng/its.rnc
+++ b/geekodoc/rng/its.rnc
@@ -1,0 +1,16 @@
+#
+# This schema integrates ITS 2.0 markup (http://www.w3.org/TR/its20/)
+# into DocBook schema (http://docbook.org)
+
+namespace its = "http://www.w3.org/2005/11/its"
+
+its-translate.type =
+  ## The nodes need to be translated
+  "yes"
+  |
+  ## The nodes must not be translated
+  "no"
+
+its-attribute.translate =
+   ## The Translate data category information to be attached to the current node
+   attribute its:translate { its-translate.type }


### PR DESCRIPTION
Needed for Stefan's releasenotes.

Integrates a `its:translate=("yes"|"no")` into the set of common attributes