### PR TITLE
Disallow xml:id on child elements of table

### DIFF
--- a/geekodoc/rng/geekodoc5-flat.rnc
+++ b/geekodoc/rng/geekodoc5-flat.rnc
@@ -6339,17 +6339,6 @@ div {
 
         ## The number of columns in the table. Must be an integer greater than zero.
         attribute cols { xsd:positiveInteger }
-      db.tgroup.attlist =
-        db.tgroup.role.attribute?
-        & db.common.attributes
-        & db.common.linking.attributes
-        & db.char.attribute?
-        & db.charoff.attribute?
-        & db.tgroup.tgroupstyle.attribute?
-        & db.tgroup.cols.attribute
-        & db.colsep.attribute?
-        & db.rowsep.attribute?
-        & db.align.attribute?
       db.tgroup =
 
         ## A wrapper for the main content of a table, or part of a table
@@ -6372,19 +6361,6 @@ div {
 
         ## Specifies the width of the column.
         attribute colwidth { text }
-      db.colspec.attlist =
-        db.colspec.role.attribute?
-        & db.common.attributes
-        & db.common.linking.attributes
-        & db.colspec.colnum.attribute?
-        & db.char.attribute?
-        & db.colsep.attribute?
-        & db.colspec.colwidth.attribute?
-        & db.charoff.attribute?
-        & db.colname.attribute?
-        & db.rowsep.attribute?
-        & db.align.attribute?
-        & db.rowheader.attribute?
       db.colspec =
 
         ## Specifications for a column in a table
@@ -6419,11 +6395,6 @@ div {
     }
     div {
       db.cals.thead.role.attribute = attribute role { text }
-      db.cals.thead.attlist =
-        db.cals.thead.role.attribute?
-        & db.common.attributes
-        & db.common.linking.attributes
-        & db.valign.attribute?
       db.cals.thead =
 
         ## A table header consisting of one or more rows
@@ -6431,11 +6402,6 @@ div {
     }
     div {
       db.cals.tfoot.role.attribute = attribute role { text }
-      db.cals.tfoot.attlist =
-        db.cals.tfoot.role.attribute?
-        & db.common.attributes
-        & db.common.linking.attributes
-        & db.valign.attribute?
       db.cals.tfoot =
 
         ## A table footer consisting of one or more rows
@@ -6443,11 +6409,6 @@ div {
     }
     div {
       db.cals.tbody.role.attribute = attribute role { text }
-      db.cals.tbody.attlist =
-        db.cals.tbody.role.attribute?
-        & db.common.attributes
-        & db.common.linking.attributes
-        & db.valign.attribute?
       db.cals.tbody =
 
         ## A wrapper for the rows of a table or informal table
@@ -10274,6 +10235,19 @@ div {
     & db.cmdsynopsis.sepchar.attribute?
     & db.cmdsynopsis.cmdlength.attribute?
     & db.cmdsynopsis.label.attribute?
+  db.colspec.attlist =
+    db.colspec.role.attribute?
+    & db.common.base.attributes
+    & db.common.linking.attributes
+    & db.colspec.colnum.attribute?
+    & db.char.attribute?
+    & db.colsep.attribute?
+    & db.colspec.colwidth.attribute?
+    & db.charoff.attribute?
+    & db.colname.attribute?
+    & db.rowsep.attribute?
+    & db.align.attribute?
+    & db.rowheader.attribute?
   db.constraintdef.attlist =
     db.constraintdef.role.attribute? & db.common.attributes
   db.classsynopsisinfo.attlist =
@@ -10339,6 +10313,53 @@ div {
     & db.frame.attribute?
     & db.pgwide.attribute?
     & db.rowheader.attribute?
+  db.cals.table.attlist =
+    db.cals.table.role.attribute?
+    & db.cals.table.label.attribute?
+    & db.common.attributes
+    & db.tabstyle.attribute?
+    & db.floatstyle.attribute?
+    & db.orient.attribute?
+    & db.colsep.attribute?
+    & db.rowsep.attribute?
+    & db.frame.attribute?
+    & db.pgwide.attribute?
+    &
+      ## Indicates if the short or long title should be used in a List of Tables
+      attribute shortentry {
+
+        ## Indicates that the full title should be used.
+        "0"
+        |
+          ## Indicates that the short short title (titleabbrev) should be used.
+          "1"
+      }?
+    &
+      ## Indicates if the table should appear in a List of Tables
+      attribute tocentry {
+
+        ## Indicates that the table should not occur in the List of Tables.
+        "0"
+        |
+          ## Indicates that the table should appear in the List of Tables.
+          "1"
+      }?
+    & db.rowheader.attribute?
+  db.cals.tbody.attlist =
+    db.cals.tbody.role.attribute?
+    & db.common.base.attributes
+    & db.common.linking.attributes
+    & db.valign.attribute?
+  db.cals.thead.attlist =
+    db.cals.thead.role.attribute?
+    & db.common.base.attributes
+    & db.common.linking.attributes
+    & db.valign.attribute?
+  db.cals.tfoot.attlist =
+    db.cals.tfoot.role.attribute?
+    & db.common.base.attributes
+    & db.common.linking.attributes
+    & db.valign.attribute?
   db.itemizedlist.attlist =
     db.itemizedlist.role.attribute?
     & db.common.attributes
@@ -10409,40 +10430,19 @@ div {
     & db.common.attributes
     & db.verbatim.attributes
     & db.synopsis.label.attribute?
-  db.cals.table.attlist =
-    db.cals.table.role.attribute?
-    & db.cals.table.label.attribute?
-    & db.common.attributes
-    & db.tabstyle.attribute?
-    & db.floatstyle.attribute?
-    & db.orient.attribute?
-    & db.colsep.attribute?
-    & db.rowsep.attribute?
-    & db.frame.attribute?
-    & db.pgwide.attribute?
-    &
-      ## Indicates if the short or long title should be used in a List of Tables
-      attribute shortentry {
-
-        ## Indicates that the full title should be used.
-        "0"
-        |
-          ## Indicates that the short short title (titleabbrev) should be used.
-          "1"
-      }?
-    &
-      ## Indicates if the table should appear in a List of Tables
-      attribute tocentry {
-
-        ## Indicates that the table should not occur in the List of Tables.
-        "0"
-        |
-          ## Indicates that the table should appear in the List of Tables.
-          "1"
-      }?
-    & db.rowheader.attribute?
   db.task.attlist = db.task.role.attribute? & db.common.attributes
   db.tip.attlist = db.tip.role.attribute? & db.common.attributes
+  db.tgroup.attlist =
+    db.tgroup.role.attribute?
+    & db.common.base.attributes
+    & db.common.linking.attributes
+    & db.char.attribute?
+    & db.charoff.attribute?
+    & db.tgroup.tgroupstyle.attribute?
+    & db.tgroup.cols.attribute
+    & db.colsep.attribute?
+    & db.rowsep.attribute?
+    & db.align.attribute?
   db.variablelist.attlist =
     db.variablelist.role.attribute?
     & db.common.attributes

--- a/geekodoc/rng/geekodoc5.rnc
+++ b/geekodoc/rng/geekodoc5.rnc
@@ -781,6 +781,20 @@ include "docbookxi.rnc"
     & db.cmdsynopsis.cmdlength.attribute?
     & db.cmdsynopsis.label.attribute?
 
+  db.colspec.attlist =
+    db.colspec.role.attribute?
+    & db.common.base.attributes
+    & db.common.linking.attributes
+    & db.colspec.colnum.attribute?
+    & db.char.attribute?
+    & db.colsep.attribute?
+    & db.colspec.colwidth.attribute?
+    & db.charoff.attribute?
+    & db.colname.attribute?
+    & db.rowsep.attribute?
+    & db.align.attribute?
+    & db.rowheader.attribute?
+
   db.constraintdef.attlist =
     db.constraintdef.role.attribute?
     & db.common.attributes
@@ -862,6 +876,53 @@ include "docbookxi.rnc"
     & db.frame.attribute?
     & db.pgwide.attribute?
     & db.rowheader.attribute?
+
+  db.cals.table.attlist =
+    db.cals.table.role.attribute?
+    & db.cals.table.label.attribute?
+    & db.common.attributes
+    & db.tabstyle.attribute?
+    & db.floatstyle.attribute?
+    & db.orient.attribute?
+    & db.colsep.attribute?
+    & db.rowsep.attribute?
+    & db.frame.attribute?
+    & db.pgwide.attribute?
+    &
+      ## Indicates if the short or long title should be used in a List of Tables
+      attribute shortentry {
+        ## Indicates that the full title should be used.
+        "0"
+        |
+        ## Indicates that the short short title (titleabbrev) should be used.
+        "1"
+      }?
+    &
+      ## Indicates if the table should appear in a List of Tables
+      attribute tocentry {
+        ## Indicates that the table should not occur in the List of Tables.
+        "0"
+        |
+        ## Indicates that the table should appear in the List of Tables.
+        "1"
+      }?
+    & db.rowheader.attribute?
+
+  db.cals.tbody.attlist =
+    db.cals.tbody.role.attribute?
+    & db.common.base.attributes
+    & db.common.linking.attributes
+    & db.valign.attribute?
+  db.cals.thead.attlist =
+    db.cals.thead.role.attribute?
+    & db.common.base.attributes
+    & db.common.linking.attributes
+    & db.valign.attribute?
+  db.cals.tfoot.attlist =
+    db.cals.tfoot.role.attribute?
+    & db.common.base.attributes
+    & db.common.linking.attributes
+    & db.valign.attribute?
 
   db.itemizedlist.attlist =
     db.itemizedlist.role.attribute?
@@ -964,39 +1025,6 @@ include "docbookxi.rnc"
     & db.verbatim.attributes
     & db.synopsis.label.attribute?
 
-  db.cals.table.attlist =
-    db.cals.table.role.attribute?
-    & db.cals.table.label.attribute?
-    & db.common.attributes
-    & db.tabstyle.attribute?
-    & db.floatstyle.attribute?
-    & db.orient.attribute?
-    & db.colsep.attribute?
-    & db.rowsep.attribute?
-    & db.frame.attribute?
-    & db.pgwide.attribute?
-    &
-      ## Indicates if the short or long title should be used in a List of Tables
-      attribute shortentry {
-
-        ## Indicates that the full title should be used.
-        "0"
-        |
-          ## Indicates that the short short title (titleabbrev) should be used.
-          "1"
-      }?
-    &
-      ## Indicates if the table should appear in a List of Tables
-      attribute tocentry {
-
-        ## Indicates that the table should not occur in the List of Tables.
-        "0"
-        |
-          ## Indicates that the table should appear in the List of Tables.
-          "1"
-      }?
-    & db.rowheader.attribute?
-
   db.task.attlist =
     db.task.role.attribute?
     & db.common.attributes
@@ -1004,6 +1032,18 @@ include "docbookxi.rnc"
   db.tip.attlist =
     db.tip.role.attribute?
     & db.common.attributes
+
+  db.tgroup.attlist =
+    db.tgroup.role.attribute?
+    & db.common.base.attributes
+    & db.common.linking.attributes
+    & db.char.attribute?
+    & db.charoff.attribute?
+    & db.tgroup.tgroupstyle.attribute?
+    & db.tgroup.cols.attribute
+    & db.colsep.attribute?
+    & db.rowsep.attribute?
+    & db.align.attribute?
 
   db.variablelist.attlist =
     db.variablelist.role.attribute?

--- a/geekodoc/tests/bad/article-id-on-colspec.xml
+++ b/geekodoc/tests/bad/article-id-on-colspec.xml
@@ -3,10 +3,12 @@
 <article xmlns="http://docbook.org/ns/docbook">
  <title>Test missing xml:id on Tables</title>
  <table>
-  <title>A Title with an xml:id on a row</title>
+  <title>A Title with an xml:id on a colspec</title>
   <tgroup cols="2">
+   <colspec xml:id="should-not-be-there" colname="c1" colwidth="1*"/>
+   <colspec colname="c2" colwidth="4*"/>
    <tbody>
-    <row xml:id="should-not-be-there">
+    <row>
      <entry>A</entry>
      <entry>B</entry>
     </row>

--- a/geekodoc/tests/bad/article-id-on-entry.xml
+++ b/geekodoc/tests/bad/article-id-on-entry.xml
@@ -3,7 +3,7 @@
 <article xmlns="http://docbook.org/ns/docbook">
  <title>Test missing xml:id on Tables</title>
  <table>
-  <title>A Title with an xml:id on a row</title>
+  <title>A Title with an xml:id on a tbody</title>
   <tgroup cols="2">
    <tbody>
     <row xml:id="should-not-be-there">

--- a/geekodoc/tests/bad/article-id-on-tbody.xml
+++ b/geekodoc/tests/bad/article-id-on-tbody.xml
@@ -3,10 +3,16 @@
 <article xmlns="http://docbook.org/ns/docbook">
  <title>Test missing xml:id on Tables</title>
  <table>
-  <title>A Title with an xml:id on a row</title>
+  <title>A Title with an xml:id on a tbody</title>
   <tgroup cols="2">
+   <thead xml:id="should-not-be-there">
+    <row>
+     <entry>Head A</entry>
+     <entry>Head B</entry>
+    </row>
+   </thead>
    <tbody>
-    <row xml:id="should-not-be-there">
+    <row>
      <entry>A</entry>
      <entry>B</entry>
     </row>

--- a/geekodoc/tests/bad/article-id-on-tfoot.xml
+++ b/geekodoc/tests/bad/article-id-on-tfoot.xml
@@ -3,10 +3,21 @@
 <article xmlns="http://docbook.org/ns/docbook">
  <title>Test missing xml:id on Tables</title>
  <table>
-  <title>A Title with an xml:id on a row</title>
+  <title>A Title with an xml:id on a tbody</title>
   <tgroup cols="2">
+   <thead xml:id="should-not-be-there">
+    <row>
+     <entry>Head A</entry>
+     <entry>Head B</entry>
+    </row>
+   </thead>
+   <tfoot xml:id="should-also-not-be-there">
+    <row>
+     <entry></entry>
+    </row>
+   </tfoot>
    <tbody>
-    <row xml:id="should-not-be-there">
+    <row>
      <entry>A</entry>
      <entry>B</entry>
     </row>

--- a/geekodoc/tests/bad/article-id-on-tgroup.xml
+++ b/geekodoc/tests/bad/article-id-on-tgroup.xml
@@ -3,10 +3,10 @@
 <article xmlns="http://docbook.org/ns/docbook">
  <title>Test missing xml:id on Tables</title>
  <table>
-  <title>A Title with an xml:id on a row</title>
-  <tgroup cols="2">
+  <title>A Title with an xml:id on a colspec</title>
+  <tgroup cols="2" xml:id="should-not-be-there">
    <tbody>
-    <row xml:id="should-not-be-there">
+    <row>
      <entry>A</entry>
      <entry>B</entry>
     </row>

--- a/geekodoc/tests/bad/article-id-on-thead.xml
+++ b/geekodoc/tests/bad/article-id-on-thead.xml
@@ -3,10 +3,16 @@
 <article xmlns="http://docbook.org/ns/docbook">
  <title>Test missing xml:id on Tables</title>
  <table>
-  <title>A Title with an xml:id on a row</title>
+  <title>A Title with an xml:id on a tbody</title>
   <tgroup cols="2">
+   <thead xml:id="should-not-be-there">
+    <row>
+     <entry>Head A</entry>
+     <entry>Head B</entry>
+    </row>
+   </thead>
    <tbody>
-    <row xml:id="should-not-be-there">
+    <row>
      <entry>A</entry>
      <entry>B</entry>
     </row>


### PR DESCRIPTION
This PR contains the following changes:

* Disallow xml:id on `colspec`, `tgroup`, `thead`, `tfoot`, `tbody`, `entry`
* Add testcase