### PR TITLE
Fix #62: restrict content model of book

### DIFF
--- a/geekodoc/rng/geekodoc5-flat.rnc
+++ b/geekodoc/rng/geekodoc5-flat.rnc
@@ -10535,9 +10535,7 @@ div {
       # (db.navigation.components | db.components | db.divisions)* | db.topic*
       (db.preface | db.xi.include)*,
       ((db.article | db.xi.include)*
-       | (db.part | db.xi.include)*
-       | (db.chapter | db.xi.include)*),
-      # (db.appendix | db.xi.include)*,
+       | (db.chapter*, (db.part | db.xi.include)*)),
       (db.navigation.components | db.appendix | db.xi.include)*
   }
   # contrib

--- a/geekodoc/rng/geekodoc5-flat.rnc
+++ b/geekodoc/rng/geekodoc5-flat.rnc
@@ -10533,9 +10533,10 @@ div {
   div {
     db.book.components =
       # (db.navigation.components | db.components | db.divisions)* | db.topic*
-      (db.preface | db.xi.include)*,
       ((db.article | db.xi.include)*
-       | (db.chapter*, (db.part | db.xi.include)*)),
+       | ((db.preface | db.xi.include)*,
+          db.chapter*,
+          (db.part | db.xi.include)*)),
       (db.navigation.components | db.appendix | db.xi.include)*
   }
   # contrib

--- a/geekodoc/rng/geekodoc5-flat.rnc
+++ b/geekodoc/rng/geekodoc5-flat.rnc
@@ -20,7 +20,7 @@ s:ns [ uri = "http://docbook.org/ns/docbook" prefix = "db" ]
 s:ns [ uri = "http://www.w3.org/1999/xlink" prefix = "xlink" ]
 s:ns [ uri = "http://www.w3.org/2005/11/its" prefix = "its" ]
 # Constants
-suse.schema.version = "5.1-subset GeekoDoc-1.0.3"
+suse.schema.version = "5.1-subset GeekoDoc-1.1.0"
 #
 div {
   div {
@@ -3846,9 +3846,6 @@ div {
           db.setindex.components?
         }
     }
-    db.book.components =
-      (db.navigation.components | db.components | db.divisions)*
-      | db.topic*
     div {
       db.book.status.attribute = db.status.attribute
       db.book.role.attribute = attribute role { text }
@@ -10532,6 +10529,16 @@ div {
         db.affiliation.attlist,
         (db.jobtitle | db.orgname | (db.jobtitle & db.orgname))
       }
+  }
+  div {
+    db.book.components =
+      # (db.navigation.components | db.components | db.divisions)* | db.topic*
+      (db.preface | db.xi.include)*,
+      ((db.article | db.xi.include)*
+       | (db.part | db.xi.include)*
+       | (db.chapter | db.xi.include)*),
+      # (db.appendix | db.xi.include)*,
+      (db.navigation.components | db.appendix | db.xi.include)*
   }
   # contrib
   div {

--- a/geekodoc/rng/geekodoc5.rnc
+++ b/geekodoc/rng/geekodoc5.rnc
@@ -1196,11 +1196,9 @@ include "docbookxi.rnc"
      (db.preface | db.xi.include)*,
      ((db.article | db.xi.include)*
       |
-      (db.part | db.xi.include)*
-      |
-      (db.chapter | db.xi.include)*
-      ),
-      (db.navigation.components | db.appendix | db.xi.include)*
+      (db.chapter*, (db.part | db.xi.include)*)
+     ),
+     (db.navigation.components | db.appendix | db.xi.include)*
   }
 
   # contrib

--- a/geekodoc/rng/geekodoc5.rnc
+++ b/geekodoc/rng/geekodoc5.rnc
@@ -1193,10 +1193,11 @@ include "docbookxi.rnc"
   div {
     db.book.components =
      # (db.navigation.components | db.components | db.divisions)* | db.topic*
-     (db.preface | db.xi.include)*,
      ((db.article | db.xi.include)*
       |
-      (db.chapter*, (db.part | db.xi.include)*)
+      ((db.preface| db.xi.include)*,
+        db.chapter*,
+        (db.part | db.xi.include)*)
      ),
      (db.navigation.components | db.appendix | db.xi.include)*
   }

--- a/geekodoc/rng/geekodoc5.rnc
+++ b/geekodoc/rng/geekodoc5.rnc
@@ -33,7 +33,7 @@ s:ns [ uri = "http://www.w3.org/1999/xlink"  prefix = "xlink" ]
 s:ns [ uri = "http://www.w3.org/2005/11/its"  prefix = "its" ]
 
 # Constants
-suse.schema.version = "5.1-subset GeekoDoc-1.0.4"
+suse.schema.version = "5.1-subset GeekoDoc-1.1.0"
 
 
 #
@@ -1188,6 +1188,19 @@ include "docbookxi.rnc"
         db.affiliation.attlist,
         (db.jobtitle | db.orgname | (db.jobtitle & db.orgname))
     }
+  }
+
+  div {
+    db.book.components =
+     # (db.navigation.components | db.components | db.divisions)* | db.topic*
+     (db.preface | db.xi.include)*,
+     ((db.article | db.xi.include)*
+      |
+      (db.part | db.xi.include)*
+      |
+      (db.chapter | db.xi.include)*
+      ),
+      (db.navigation.components | db.appendix | db.xi.include)*
   }
 
   # contrib

--- a/geekodoc/tests/bad/book-article-structure.xml
+++ b/geekodoc/tests/bad/book-article-structure.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../rng/geekodoc5-flat.rnc" type="application/relax-ng-compact-syntax"?>
+<book xmlns="http://docbook.org/ns/docbook" version="5.1-subset GeekoDoc-1.1.0">
+  <title>Test Structure Book</title>
+  <preface>
+   <title>Shouldn't be there</title>
+   <para/>
+  </preface>
+ <article>
+  <title>First Article</title>
+  <para/>
+ </article>
+</book>

--- a/geekodoc/tests/bad/book-part-structure.xml
+++ b/geekodoc/tests/bad/book-part-structure.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../rng/geekodoc5-flat.rnc" type="application/relax-ng-compact-syntax"?>
+<book xmlns="http://docbook.org/ns/docbook" version="5.1-subset GeekoDoc-1.1.0">
+  <title>Test Structure Book</title>
+  <preface>
+   <title>Preface</title>
+   <para/>
+  </preface>
+ <chapter>
+  <title>First</title>
+  <para/>
+ </chapter>
+ <part>
+  <title>Part One</title>
+  <chapter>
+   <title>Chapter Two</title>
+   <para/>
+  </chapter>
+ </part>
+ <chapter>
+   <title>Shouldn't be there</title>
+   <para/>
+  </chapter>
+</book>

--- a/geekodoc/tests/bad/book-structure.xml
+++ b/geekodoc/tests/bad/book-structure.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../rng/geekodoc5-flat.rnc" type="application/relax-ng-compact-syntax"?>
+<book xmlns="http://docbook.org/ns/docbook" version="5.1-subset GeekoDoc-1.1.0">
+  <title>Test Structure Book</title>
+  <preface>
+   <title>Preface</title>
+   <para/>
+  </preface>
+ <chapter>
+  <title>First</title>
+  <para/>
+ </chapter>
+ <preface>
+  <title>Shouldn't be there</title>
+  <para/>
+ </preface>
+</book>


### PR DESCRIPTION
This PR contains:

* change to restrict content model of book according to #62 
* Testcases

@sknorr if your time permits, I've corrected the book content modell. The changes are not pretty, but it seems to work (what I've tested so far).

This will be valid:

```
book
   preface
   chapter
   chapter
   glossary
   appendix
```

but this is not:

```
book
   chapter
   preface
   chapter
   glossary
   appendix
```