### PR TITLE
Fix #61: remove depth attribute on imagedata

### DIFF
--- a/geekodoc/rng/geekodoc5-flat.rnc
+++ b/geekodoc/rng/geekodoc5-flat.rnc
@@ -2410,7 +2410,6 @@ div {
         ## Specifies the vertical alignment of the image data
         attribute valign { db.imagedata.valign.enumeration }
       db.imagedata.width.attribute = db.width.attribute
-      db.imagedata.depth.attribute = db.depth.attribute
       db.imagedata.contentwidth.attribute = db.contentwidth.attribute
       db.imagedata.contentdepth.attribute = db.contentdepth.attribute
       db.imagedata.scalefit.enumeration = db.scalefit.enumeration
@@ -10051,6 +10050,7 @@ div {
   # Disallow mediaobject in certain contexts
   db.graphic.blocks = notAllowed
   # ======== Removed Attribute
+  db.imagedata.depth.attribute = empty
   db.rdfalite.attributes = empty
   db.xlink.attributes = empty
   # We don't want/need xreflabel

--- a/geekodoc/rng/geekodoc5.rnc
+++ b/geekodoc/rng/geekodoc5.rnc
@@ -592,6 +592,7 @@ include "docbookxi.rnc"
 
   #======== Removed Attribute
 
+  db.imagedata.depth.attribute = empty
   db.rdfalite.attributes = empty
   db.xlink.attributes = empty
   # We don't want/need xreflabel

--- a/geekodoc/tests/bad/article-depth-on-imagedata.xml
+++ b/geekodoc/tests/bad/article-depth-on-imagedata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../rng/geekodoc5-flat.rnc" type="application/relax-ng-compact-syntax"?>
+<article xmlns="http://docbook.org/ns/docbook">
+ <title>Test of depth attribute on imagedata</title>
+ <informalfigure >
+  <mediaobject>
+   <imageobject>
+    <imagedata fileref="foo.png" depth="120"/>
+   </imageobject>
+  </mediaobject>
+ </informalfigure>
+</article>


### PR DESCRIPTION
This PR contains the following changes:

* Remove `depth` attribute on `imagedata`
* Add testcase