### PR TITLE
Attempt to consolidate admon content model #60

### DIFF
--- a/geekodoc/rng/geekodoc5-flat.rnc
+++ b/geekodoc/rng/geekodoc5-flat.rnc
@@ -8806,7 +8806,6 @@ div {
           db.programlisting.attlist, db.verbatim.contentmodel
         }
     }
-    db.admonition.contentmodel = db._info.title.only, db.all.blocks+
     div {
       db.caution.role.attribute = attribute role { text }
       db.caution =
@@ -10513,6 +10512,13 @@ div {
 
   # Admonitions
   div {
+    db.admonition.contentmodel =
+      db._info.title.only,
+      (db.list.blocks
+       | db.verbatim.blocks
+       | db.remark
+       | db.para
+       | db.xi.include)+
     db.admonition.blocks =
       # Removed caution
       db.important

--- a/geekodoc/rng/geekodoc5.rnc
+++ b/geekodoc/rng/geekodoc5.rnc
@@ -1175,6 +1175,15 @@ include "docbookxi.rnc"
 
   # Admonitions
   div {
+    db.admonition.contentmodel =
+      db._info.title.only,
+      (db.list.blocks
+      | db.verbatim.blocks
+      | db.remark
+      | db.para
+      | db.xi.include
+      )+
+
     db.admonition.blocks =
       # Removed caution
       db.important | db.note | db.tip | db.warning

--- a/geekodoc/tests/bad/article-admonitions.xml
+++ b/geekodoc/tests/bad/article-admonitions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../rng/geekodoc5-flat.rnc" type="application/relax-ng-compact-syntax"?>
+<article xmlns="http://docbook.org/ns/docbook"
+    xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0">
+    <title>Admonitions</title>
+  <important>
+   <title/>
+   <formalpara><title/><para/></formalpara>
+  </important>
+  <tip>
+   <title/>
+   <mediaobject>
+    <imageobject>
+     <imagedata fileref="unknown.png"/>
+    </imageobject>
+   </mediaobject>
+  </tip>
+  <warning>
+   <title/>
+   <blockquote><para/></blockquote>
+  </warning>
+  <important>
+    <example><screen/></example>
+  </important>
+</article>


### PR DESCRIPTION
This PR contains the following changes:

* Disallow `formalpara`
* Reduce content model of admonitions in general
  => allow `remark`, `para`, lists, `screen`, and `xi:include`.
* Add testcase