### PR TITLE
Fix #69: reduce content model of replaceable

### DIFF
--- a/geekodoc/rng/geekodoc5-flat.rnc
+++ b/geekodoc/rng/geekodoc5-flat.rnc
@@ -3423,12 +3423,6 @@ div {
         & db.common.attributes
         & db.common.linking.attributes
         & db.replaceable.class.attribute?
-      db.replaceable =
-
-        ## Content that may or must be replaced by the user
-        element replaceable {
-          db.replaceable.attlist, db.replaceable.inlines*
-        }
     }
     div {
       db.uri.type.attribute =
@@ -10837,6 +10831,15 @@ div {
 
       ## A question in a QandASet
       element question { db.question.attlist, db.para, db.all.blocks* }
+  }
+  # replaceable
+  div {
+    db.replaceable =
+
+      ## Content that may or must be replaced by the user
+      element replaceable {
+        db.replaceable.attlist, (text | db.emphasis | db.phrase)*
+      }
   }
   # result: restrict content model and allow only certain elements
   div {

--- a/geekodoc/rng/geekodoc5.rnc
+++ b/geekodoc/rng/geekodoc5.rnc
@@ -1486,6 +1486,16 @@ include "docbookxi.rnc"
       }
   }
 
+  # replaceable
+  div {
+    db.replaceable =
+      ## Content that may or must be replaced by the user
+      element replaceable {
+        db.replaceable.attlist,
+        (text | db.emphasis | db.phrase)*
+      }
+  }
+
   # result: restrict content model and allow only certain elements
   div {
    db.result =

--- a/geekodoc/tests/bad/article-replaceable.xml
+++ b/geekodoc/tests/bad/article-replaceable.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../rng/geekodoc5-flat.rnc" type="application/relax-ng-compact-syntax"?>
+<article xmlns="http://docbook.org/ns/docbook" version="5.1">
+ <title>Test invalid elements in replaceable</title>
+ <para>
+  <replaceable><alt/></replaceable>
+  <replaceable><date/></replaceable>
+  <replaceable><firstterm/></replaceable>
+  <replaceable><footnote/></replaceable>
+  <replaceable><foreignphrase/></replaceable>
+  <replaceable><glossterm/></replaceable>
+  <replaceable><indexterm/></replaceable>
+  <replaceable><inlinemediaobject/></replaceable>
+  <replaceable><quote/></replaceable>
+  <replaceable><remark/></replaceable>
+  <replaceable><subscript/></replaceable>
+  <replaceable><superscript/></replaceable>
+  <replaceable><trademark/></replaceable>
+  <replaceable><xref/></replaceable>
+ </para>
+</article>


### PR DESCRIPTION
This PR fixes #69 with the following changes:

* Reduce content model of `replaceable`: allow emphasis, phrase, and text only.
* Add testcase
