### PR TITLE
Fix #64: disallow empty sections

### DIFF
--- a/geekodoc/rng/geekodoc5-flat.rnc
+++ b/geekodoc/rng/geekodoc5-flat.rnc
@@ -4084,38 +4084,6 @@ div {
       db.section.status.attribute = db.status.attribute
       db.section.role.attribute = attribute role { text }
       db.section.info = db._info.title.req
-      db.section =
-
-        ## A recursive section
-        [
-          s:pattern [
-            "\x{a}" ~
-            "              "
-            rng:title [ "Root must have version" ]
-            "\x{a}" ~
-            "              "
-            s:rule [
-              context = "/db:section"
-              "\x{a}" ~
-              "                "
-              s:assert [
-                test = "@version"
-                "If this element is the root element, it must have a version attribute."
-              ]
-              "\x{a}" ~
-              "              "
-            ]
-            "\x{a}" ~
-            "            "
-          ]
-        ]
-        element section {
-          db.section.attlist,
-          db.section.info,
-          db.navigation.components*,
-          db.recursive.blocks.or.sections?,
-          db.navigation.components*
-        }
     }
     div {
       db.simplesect.status.attribute = db.status.attribute
@@ -4509,38 +4477,6 @@ div {
       db.sect1.status.attribute = db.status.attribute
       db.sect1.role.attribute = attribute role { text }
       db.sect1.info = db._info.title.req
-      db.sect1 =
-
-        ## A top-level section of document
-        [
-          s:pattern [
-            "\x{a}" ~
-            "              "
-            rng:title [ "Root must have version" ]
-            "\x{a}" ~
-            "              "
-            s:rule [
-              context = "/db:sect1"
-              "\x{a}" ~
-              "                "
-              s:assert [
-                test = "@version"
-                "If this element is the root element, it must have a version attribute."
-              ]
-              "\x{a}" ~
-              "              "
-            ]
-            "\x{a}" ~
-            "            "
-          ]
-        ]
-        element sect1 {
-          db.sect1.attlist,
-          db.sect1.info,
-          db.navigation.components*,
-          ((db.all.blocks+, db.sect1.sections?) | db.sect1.sections)?,
-          db.navigation.components*
-        }
     }
     db.sect2.sections =
       ((db.sect3+, db.simplesect*) | db.simplesect+)
@@ -4549,38 +4485,6 @@ div {
       db.sect2.status.attribute = db.status.attribute
       db.sect2.role.attribute = attribute role { text }
       db.sect2.info = db._info.title.req
-      db.sect2 =
-
-        ## A subsection within a sect1
-        [
-          s:pattern [
-            "\x{a}" ~
-            "              "
-            rng:title [ "Root must have version" ]
-            "\x{a}" ~
-            "              "
-            s:rule [
-              context = "/db:sect2"
-              "\x{a}" ~
-              "                "
-              s:assert [
-                test = "@version"
-                "If this element is the root element, it must have a version attribute."
-              ]
-              "\x{a}" ~
-              "              "
-            ]
-            "\x{a}" ~
-            "            "
-          ]
-        ]
-        element sect2 {
-          db.sect2.attlist,
-          db.sect2.info,
-          db.navigation.components*,
-          ((db.all.blocks+, db.sect2.sections?) | db.sect2.sections)?,
-          db.navigation.components*
-        }
     }
     db.sect3.sections =
       ((db.sect4+, db.simplesect*) | db.simplesect+)
@@ -4589,38 +4493,6 @@ div {
       db.sect3.status.attribute = db.status.attribute
       db.sect3.role.attribute = attribute role { text }
       db.sect3.info = db._info.title.req
-      db.sect3 =
-
-        ## A subsection within a sect2
-        [
-          s:pattern [
-            "\x{a}" ~
-            "              "
-            rng:title [ "Root must have version" ]
-            "\x{a}" ~
-            "              "
-            s:rule [
-              context = "/db:sect3"
-              "\x{a}" ~
-              "                "
-              s:assert [
-                test = "@version"
-                "If this element is the root element, it must have a version attribute."
-              ]
-              "\x{a}" ~
-              "              "
-            ]
-            "\x{a}" ~
-            "            "
-          ]
-        ]
-        element sect3 {
-          db.sect3.attlist,
-          db.sect3.info,
-          db.navigation.components*,
-          ((db.all.blocks+, db.sect3.sections?) | db.sect3.sections)?,
-          db.navigation.components*
-        }
     }
     db.sect4.sections =
       ((db.sect5+, db.simplesect*) | db.simplesect+)
@@ -4629,38 +4501,6 @@ div {
       db.sect4.status.attribute = db.status.attribute
       db.sect4.role.attribute = attribute role { text }
       db.sect4.info = db._info.title.req
-      db.sect4 =
-
-        ## A subsection within a sect3
-        [
-          s:pattern [
-            "\x{a}" ~
-            "              "
-            rng:title [ "Root must have version" ]
-            "\x{a}" ~
-            "              "
-            s:rule [
-              context = "/db:sect4"
-              "\x{a}" ~
-              "                "
-              s:assert [
-                test = "@version"
-                "If this element is the root element, it must have a version attribute."
-              ]
-              "\x{a}" ~
-              "              "
-            ]
-            "\x{a}" ~
-            "            "
-          ]
-        ]
-        element sect4 {
-          db.sect4.attlist,
-          db.sect4.info,
-          db.navigation.components*,
-          ((db.all.blocks+, db.sect4.sections?) | db.sect4.sections)?,
-          db.navigation.components*
-        }
     }
     db.sect5.sections =
       db.simplesect+ | (db.simplesect | db.xi.include)+
@@ -4668,38 +4508,6 @@ div {
       db.sect5.status.attribute = db.status.attribute
       db.sect5.role.attribute = attribute role { text }
       db.sect5.info = db._info.title.req
-      db.sect5 =
-
-        ## A subsection within a sect4
-        [
-          s:pattern [
-            "\x{a}" ~
-            "              "
-            rng:title [ "Root must have version" ]
-            "\x{a}" ~
-            "              "
-            s:rule [
-              context = "/db:sect5"
-              "\x{a}" ~
-              "                "
-              s:assert [
-                test = "@version"
-                "If this element is the root element, it must have a version attribute."
-              ]
-              "\x{a}" ~
-              "              "
-            ]
-            "\x{a}" ~
-            "            "
-          ]
-        ]
-        element sect5 {
-          db.sect5.attlist,
-          db.sect5.info,
-          db.navigation.components*,
-          ((db.all.blocks+, db.sect5.sections?) | db.sect5.sections)?,
-          db.navigation.components*
-        }
     }
     db.toplevel.refsection =
       db.refsection+
@@ -10854,6 +10662,69 @@ div {
          | db.orderedlist
          | db.itemizedlist
          | db.simplelist)+
+      }
+  }
+  # sect1, sect2, sect3, section
+  div {
+    db.sect1 =
+
+      ## A top-level section of document
+      element sect1 {
+        db.sect1.attlist,
+        db.sect1.info,
+        db.navigation.components*,
+        ((db.all.blocks+, db.sect1.sections?) | db.sect1.sections),
+        db.navigation.components*
+      }
+    db.sect2 =
+
+      ## A subsection within a sect1
+      element sect2 {
+        db.sect2.attlist,
+        db.sect2.info,
+        db.navigation.components*,
+        ((db.all.blocks+, db.sect2.sections?) | db.sect2.sections),
+        db.navigation.components*
+      }
+    db.sect3 =
+
+      ## A subsection within a sect2
+      element sect3 {
+        db.sect3.attlist,
+        db.sect3.info,
+        db.navigation.components*,
+        ((db.all.blocks+, db.sect3.sections?) | db.sect3.sections),
+        db.navigation.components*
+      }
+    db.sect4 =
+
+      ## A subsection within a sect3
+      element sect4 {
+        db.sect4.attlist,
+        db.sect4.info,
+        db.navigation.components*,
+        ((db.all.blocks+, db.sect4.sections?) | db.sect4.sections),
+        db.navigation.components*
+      }
+    db.sect5 =
+
+      ## A subsection within a sect4
+      element sect5 {
+        db.sect5.attlist,
+        db.sect5.info,
+        db.navigation.components*,
+        ((db.all.blocks+, db.sect5.sections?) | db.sect5.sections),
+        db.navigation.components*
+      }
+    db.section =
+
+      ## A recursive section
+      element section {
+        db.section.attlist,
+        db.section.info,
+        db.navigation.components*,
+        db.recursive.blocks.or.sections,
+        db.navigation.components*
       }
   }
   # step

--- a/geekodoc/rng/geekodoc5.rnc
+++ b/geekodoc/rng/geekodoc5.rnc
@@ -1499,6 +1499,69 @@ include "docbookxi.rnc"
     }
   }
 
+  # sect1, sect2, sect3, section
+  div {
+    db.sect1 =
+      ## A top-level section of document
+      element sect1 {
+        db.sect1.attlist,
+        db.sect1.info,
+        db.navigation.components*,
+        ((db.all.blocks+, db.sect1.sections?) | db.sect1.sections),
+        db.navigation.components*
+      }
+
+    db.sect2 =
+      ## A subsection within a sect1
+      element sect2 {
+        db.sect2.attlist,
+        db.sect2.info,
+        db.navigation.components*,
+        ((db.all.blocks+, db.sect2.sections?) | db.sect2.sections),
+        db.navigation.components*
+      }
+
+    db.sect3 =
+      ## A subsection within a sect2
+      element sect3 {
+        db.sect3.attlist,
+        db.sect3.info,
+        db.navigation.components*,
+        ((db.all.blocks+, db.sect3.sections?) | db.sect3.sections),
+        db.navigation.components*
+      }
+
+    db.sect4 =
+      ## A subsection within a sect3
+      element sect4 {
+        db.sect4.attlist,
+        db.sect4.info,
+        db.navigation.components*,
+        ((db.all.blocks+, db.sect4.sections?) | db.sect4.sections),
+        db.navigation.components*
+      }
+
+    db.sect5 =
+      ## A subsection within a sect4
+      element sect5 {
+        db.sect5.attlist,
+        db.sect5.info,
+        db.navigation.components*,
+        ((db.all.blocks+, db.sect5.sections?) | db.sect5.sections),
+        db.navigation.components*
+      }
+
+    db.section =
+      ## A recursive section
+      element section {
+        db.section.attlist,
+        db.section.info,
+        db.navigation.components*,
+        db.recursive.blocks.or.sections,
+        db.navigation.components*
+      }
+  }
+
   # step
   div {
     # Replaced db.all.blocks -> db.step.blocks

--- a/geekodoc/tests/bad/article-sectXs.xml
+++ b/geekodoc/tests/bad/article-sectXs.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../rng/geekodoc5-flat.rnc" type="application/relax-ng-compact-syntax"?> 
+<article xmlns="http://docbook.org/ns/docbook" version="5.1">
+ <title>Test for invalid sections</title>
+ <sect1>
+  <title/>
+ </sect1>
+ <sect1>
+  <title/>
+  <sect2>
+   <title/>
+  </sect2>
+ </sect1>
+ <sect1>
+  <title/>
+  <sect2>
+   <title/>
+   <sect3>
+    <title/>
+   </sect3>
+  </sect2>
+ </sect1>
+ <sect1>
+  <title/>
+  <sect2>
+   <title/>
+   <sect3>
+    <title/>
+    <sect4>
+     <title/>
+    </sect4>
+   </sect3>
+  </sect2>
+ </sect1>
+ <sect1>
+  <title/>
+  <sect2>
+   <title/>
+   <sect3>
+    <title/>
+    <sect4>
+     <title/>
+     <sect5>
+      <title/>
+     </sect5>
+    </sect4>
+   </sect3>
+  </sect2>
+ </sect1>
+</article>

--- a/geekodoc/tests/bad/article-sections.xml
+++ b/geekodoc/tests/bad/article-sections.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../rng/geekodoc5-flat.rnc" type="application/relax-ng-compact-syntax"?> 
+<article xmlns="http://docbook.org/ns/docbook" version="5.1">
+ <title>Test for invalid sections</title>
+ <section>
+  <title/>
+ </section>
+</article>


### PR DESCRIPTION
This PR fixes #64 and contains the following changes:

* Change content model to disallow empty sections for `sectX` and `section`
* Add testcase