### PR TITLE
Fix #80: disallow xml:id on listitems

### DIFF
--- a/geekodoc/rng/1_5.1/geekodoc-v1.rnc
+++ b/geekodoc/rng/1_5.1/geekodoc-v1.rnc
@@ -1716,6 +1716,17 @@ include "docbookxi.rnc"
       }
   }
 
+
+  # Issue #80:
+  # Disallow xml:id on listitems
+  db.listitem.attlist =
+    db.listitem.role.attribute?
+    # db.common.attributes without
+    #  db.xml.id.attribute? and db.common.linking.attributes
+    & db.common.base.attributes
+    & db.annotations.attribute?
+    & db.listitem.override.attribute?
+
   # Issue #51:
   # Reduce content model in screen
   # screen/programlisting content model

--- a/geekodoc/rng/2_5.2/geekodoc-v2.rnc
+++ b/geekodoc/rng/2_5.2/geekodoc-v2.rnc
@@ -1694,6 +1694,15 @@ include "db52itsxi.rnc"
       }
   }
 
+  # Issue #80:
+  # Disallow xml:id on listitems
+  db.listitem.attlist =
+    db.listitem.role.attribute?
+    # db.common.attributes without
+    #  db.xml.id.attribute? and db.common.linking.attributes
+    & db.common.base.attributes
+    & db.annotations.attribute?
+
   # Issue #51:
   # Reduce content model in screen
   # screen/programlisting content model

--- a/tests/v1/bad/geekodoc-v1-flat.rnc
+++ b/tests/v1/bad/geekodoc-v1-flat.rnc
@@ -1,1 +1,0 @@
-../../../geekodoc/rng/5.1_1/geekodoc-v1-flat.rnc

--- a/tests/v1/bad/listitem-xmlid.xml
+++ b/tests/v1/bad/listitem-xmlid.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="geekodoc-v1.rnc" type="application/relax-ng-compact-syntax"?>
+<article xmlns="http://docbook.org/ns/docbook">
+  <title/>
+  <orderedlist>
+    <listitem xml:id="xxx" >
+      <para/>
+    </listitem>
+  </orderedlist>
+</article>

--- a/tests/v2/bad/listitem-xmlid.xml
+++ b/tests/v2/bad/listitem-xmlid.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="geekodoc-v2.rnc" type="application/relax-ng-compact-syntax"?>
+<article xmlns="http://docbook.org/ns/docbook">
+  <title/>
+  <orderedlist>
+    <listitem xml:id="xxx" >
+      <para/>
+    </listitem>
+  </orderedlist>
+</article>


### PR DESCRIPTION
This PR fixes #80 and contains:

* An adapted `db.listitem.attlist` pattern without `db.xml.id.attribute` and `db.common.linking.attributes`
* A test case which detects `xml:id` on a `listitem` element.