### PR TITLE
Remove FIG format, add DITAA

### DIFF
--- a/geekodoc/rng/2_5.2/geekodoc-v2.rnc
+++ b/geekodoc/rng/2_5.2/geekodoc-v2.rnc
@@ -135,22 +135,10 @@ div {
      "DIA" |
      ## Format of the dia tool
      "dia" |
-     ## Encapsulated PostScript
-     "EPS" |
-     ## Encapsulated PostScript
-     "eps" |
-     ## Format of the xfig tool
-     "FIG" |
-     ## Format of the xfig tool
-     "fig" |
      ## LibreOffice illustration format
      "ODG" |
      ## LibreOffice illustration format
      "odg" |
-     ## Portable Document Format
-     "PDF" |
-     ## Portable Document Format
-     "pdf" |
      ## Portable Network Graphics
      "PNG" |
      ## Portable Network Graphics

--- a/geekodoc/rng/2_5.2/geekodoc-v2.rnc
+++ b/geekodoc/rng/2_5.2/geekodoc-v2.rnc
@@ -135,6 +135,9 @@ div {
      "DIA" |
      ## Format of the dia tool
      "dia" |
+     ## Format of the ditaa tool
+     "DITAA" |
+     "ditaa" |
      ## LibreOffice illustration format
      "ODG" |
      ## LibreOffice illustration format


### PR DESCRIPTION
I am sure these make sense:
* FIG is no longer supported with DAPS 3.1 and above
* likewise EPS and PDF are no longer supported with DAPS 3.1 and above

I am not sure about the second commit:
* DITAA is newly supported in DAPS 3.1 -- however, it is _not_ an output format, it is an input format only. I wonder if it makes any sense to list all these input-only formats.

As an addendum, I am wondering if it makes sense to list both "jpg" and "jpeg". As far as I can see, DAPS only supports "jpg". I could add a third commit to fix that too. 