### PR TITLE
Fix #78: Allow guilabel

### DIFF
--- a/geekodoc/rng/2_5.2/geekodoc-v2.rnc
+++ b/geekodoc/rng/2_5.2/geekodoc-v2.rnc
@@ -322,7 +322,7 @@ include "db52itsxi.rnc"
   db.group = notAllowed
   db.guibutton = notAllowed
   db.guiicon = notAllowed
-  db.guilabel = notAllowed
+  # db.guilabel = notAllowed
   # db.guimenu = notAllowed
   db.guimenuitem = notAllowed
   db.guisubmenu = notAllowed

--- a/tests/v2/good/article-guilabel.xml
+++ b/tests/v2/good/article-guilabel.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="geekodoc-v1-flat.rnc" type="application/relax-ng-compact-syntax"?>
+<article xmlns="http://docbook.org/ns/docbook" xml:lang="en" xml:id="article-admons">
+ <title>Test Article for <tag>guilabel</tag></title>
+ <para>See <guilabel>Configuration</guilabel>.</para>
+</article>


### PR DESCRIPTION
The guimenu element is not always the right choice for UI elements. Therefor, adding guilabel may be a more neutral element