### PR TITLE
Fix #105: Add para for lists

### DIFF
--- a/geekodoc/rng/2_5.2/geekodoc-v2.rnc
+++ b/geekodoc/rng/2_5.2/geekodoc-v2.rnc
@@ -1737,7 +1737,7 @@ include "db52itsxi.rnc"
       element calloutlist {
         db.calloutlist.attlist,
         db.calloutlist.info,
-        # db.para.blocks*,
+        db.para.blocks*,
         db.callout+
       }
 
@@ -1746,7 +1746,7 @@ include "db52itsxi.rnc"
       element itemizedlist {
         db.itemizedlist.attlist,
         db.itemizedlist.info,
-        # db.para.blocks*,
+        db.para.blocks*,
         db.listitem+
       }
 
@@ -1755,7 +1755,7 @@ include "db52itsxi.rnc"
       element orderedlist {
         db.orderedlist.attlist,
         db.orderedlist.info,
-        # db.para.blocks*,
+        db.para.blocks*,
         db.listitem+
       }
 
@@ -1764,7 +1764,7 @@ include "db52itsxi.rnc"
       element variablelist {
         db.variablelist.attlist,
         db.variablelist.info,
-        # db.para.blocks*,
+        db.para.blocks*,
         db.varlistentry+
       }
   }

--- a/tests/v2/bad/lists-105.xml
+++ b/tests/v2/bad/lists-105.xml
@@ -1,0 +1,32 @@
+<?xml-model href="geekodoc-v2-flat.rnc" type="application/relax-ng-compact-syntax"?>
+<article xmlns="http://docbook.org/ns/docbook" version="5.2">
+  <title>Testing Issue #105</title>
+
+  <itemizedlist>
+    <caution>
+      <para>Caution is not allowed</para>
+    </caution>
+    <listitem>
+      <para />
+    </listitem>
+  </itemizedlist>
+
+  <orderedlist>
+    <note>
+      <para>Note is not allowed</para>
+    </note>
+    <listitem>
+      <para/>
+    </listitem>
+  </orderedlist>
+
+  <variablelist>
+    <screen>A screen is not allowed</screen>
+    <varlistentry>
+      <term>A term</term>
+      <listitem>
+        <para/>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+</article>

--- a/tests/v2/good/lists-105.xml
+++ b/tests/v2/good/lists-105.xml
@@ -1,0 +1,41 @@
+<?xml-model href="geekodoc-v2-flat.rnc" type="application/relax-ng-compact-syntax"?>
+<article xmlns="http://docbook.org/ns/docbook" version="5.2">
+  <title>Testing Issue #105</title>
+  <itemizedlist>
+    <title>A title</title>
+    <para>A paragraph</para>
+    <listitem>
+      <para/>
+    </listitem>
+  </itemizedlist>
+
+  <itemizedlist>
+    <title>A title</title>
+    <para>A paragraph</para>
+    <formalpara>
+      <title>A formalpara title</title>
+      <para/>
+    </formalpara>
+    <listitem>
+      <para/>
+    </listitem>
+  </itemizedlist>
+
+  <orderedlist>
+    <para>A paragraph</para>
+    <listitem>
+      <para/>
+    </listitem>
+  </orderedlist>
+
+  <variablelist>
+    <para>A paragraph</para>
+    <varlistentry>
+      <term>A term</term>
+      <listitem>
+        <para/>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+
+</article>


### PR DESCRIPTION
Allow `<para>` and `<formalpara>` after lists like `orderedlist`, `itemizedlist`, or `variablelist`. Example:

```xml
<variablelist>
  <title>...</title>
  <para>
    I need to add a brief explanation here.
  </para>
  <varlistentry>
```