### PR TITLE
Remove entityref from {audio,image,text,video}data

### DIFF
--- a/geekodoc/rng/2_5.2/geekodoc-v2.rnc
+++ b/geekodoc/rng/2_5.2/geekodoc-v2.rnc
@@ -1182,9 +1182,9 @@ include "db52itsxi.rnc"
    (
     ## Indentifies the location of the data by URI
     attribute fileref { xsd:anyURI }
-    |
-    ## Identifies the location of the data by external identifier (entity name)
-    attribute entityref { xsd:ENTITY }
+    # |
+    # ## Identifies the location of the data by external identifier (entity name)
+    # attribute entityref { xsd:ENTITY }
    )
 
   # restrict prompts only allowing root/user/custom prompts ("root" and

--- a/tests/v2/bad/entityref.xml
+++ b/tests/v2/bad/entityref.xml
@@ -1,0 +1,16 @@
+<?xml-model href="geekodoc-v2-flat.rnc" type="application/relax-ng-compact-syntax"?>
+<!DOCTYPE article
+[
+  <!ENTITY image SYSTEM "image.png" NDATA PNG>
+]>
+<article xmlns="http://docbook.org/ns/docbook" xml:lang="en" xml:id="article-admons">
+ <title>Test Article for entityref attribute</title>
+  <informalfigure>
+    <mediaobject>
+      <imageobject>
+        <!-- error: element "imagedata" missing required attribute "fileref" -->
+        <imagedata format="PNG" entityref="image"/>
+      </imageobject>
+    </mediaobject>
+  </informalfigure>
+</article>


### PR DESCRIPTION
That attribute occurs in `audiodata`, `imagedata`, `textdata`, and `videodata` together with `fileref`.
We don't use the `entityref` attribute at all and it's confusing. It needs a weird syntax in the DOCTYPE header.

=> Only allow to refer to resources with `fileref`