### PR TITLE
Fix #128: Restrict `<date>` to ISO date

### DIFF
--- a/geekodoc/rng/2_5.2/geekodoc-v2.rnc
+++ b/geekodoc/rng/2_5.2/geekodoc-v2.rnc
@@ -572,6 +572,9 @@ include "db52itsxi.rnc"
   #======== General Patterns
   db.cover.contentmodel = db.mediaobject+
 
+  # ISO date
+  db.date.contentmodel = xsd:date { pattern = "[0-9]{4}-[0-9]{2}-[0-9]{2}" }
+
   db.nopara.blocks =
     db.list.blocks
      | db.formal.blocks
@@ -1812,6 +1815,5 @@ include "db52itsxi.rnc"
 
 
 # Redefine content model here:
-
 
 # --- EOF ---

--- a/tests/v2/bad/date.xml
+++ b/tests/v2/bad/date.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="file:/home/toms/repos/GH/opensuse/geekodoc/geekodoc/rng/2_5.2/geekodoc-v2.rnc" type="application/relax-ng-compact-syntax"?>
+<article xmlns="http://docbook.org/ns/docbook">
+  <title>Validating a <tag>date</tag> tag with ISO date</title>
+  <info>
+    <date>2025-08-00</date>
+    <date>2025-98-0</date>
+  </info>
+  <para></para>
+</article>

--- a/tests/v2/good/date.xml
+++ b/tests/v2/good/date.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="file:/home/toms/repos/GH/opensuse/geekodoc/geekodoc/rng/2_5.2/geekodoc-v2.rnc" type="application/relax-ng-compact-syntax"?>
+<article xmlns="http://docbook.org/ns/docbook">
+  <title>Validating a <tag>date</tag> tag with ISO date</title>
+  <info>
+    <date>2025-05-29</date>
+    <date>2025-01-01</date>
+  </info>
+  <para></para>
+</article>


### PR DESCRIPTION
This fix restricts to `<date>` and allows only an ISO date.

ISO date helps to make a date unambiguous. Needed for our metadata.

* Add restriction in Geekodoc
* Add tests